### PR TITLE
Fix for Nikon cameras which store the exposure time differently

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -137,9 +137,6 @@ void ExposureSeries::check() {
             exp.exposure = it->toFloat();
         }
 
-        exp.exposure = std::pow(2, -it->toFloat());
-        //exp.exposure = exposureTime(it->toFloat());
-
         it = Exiv2::exposureTime(exifData);
         if (it == exifData.end())
             throw std::runtime_error("\"" + exp.filename + "\": could not extract the exposure time!");


### PR DESCRIPTION
Removed the write to the exposure time variable. This write was
duplicated in the previous if else clauses, but was not removed.